### PR TITLE
Don't explicitly define library type

### DIFF
--- a/sdk/src/cameras/compression/CMakeLists.txt
+++ b/sdk/src/cameras/compression/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SOURCE_FILES
     compression_mock.cpp
 )
 
-add_library(${PROJECT_NAME} STATIC ${SOURCE_FILES})
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 install(TARGETS ${PROJECT_NAME} DESTINATION lib)
 

--- a/sdk/src/cameras/playback/CMakeLists.txt
+++ b/sdk/src/cameras/playback/CMakeLists.txt
@@ -44,7 +44,7 @@ set(SOURCE_FILES_FILE
 )
 
 #Building Library
-add_library(${PROJECT_NAME} STATIC
+add_library(${PROJECT_NAME}
     ${SOURCE_FILES_BASE}
     ${SOURCE_FILES_LINUX}
     ${SOURCE_FILES_WINDOWS}

--- a/sdk/src/cameras/record/CMakeLists.txt
+++ b/sdk/src/cameras/record/CMakeLists.txt
@@ -27,7 +27,7 @@ set(SOURCE_FILES
 
 #------------------------------------------------------------------------------------
 #Building Library
-add_library(${PROJECT_NAME} STATIC
+add_library(${PROJECT_NAME}
     ${SOURCE_FILES}
 )
 

--- a/sdk/src/core/image/CMakeLists.txt
+++ b/sdk/src/core/image/CMakeLists.txt
@@ -35,7 +35,7 @@ set(SOURCE_FILES
 
 #------------------------------------------------------------------------------------
 #Building Library
-add_library(${PROJECT_NAME} STATIC
+add_library(${PROJECT_NAME}
     ${SOURCE_FILES}
 )
 

--- a/sdk/src/core/projection/CMakeLists.txt
+++ b/sdk/src/core/projection/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(
 
 #------------------------------------------------------------------------------------
 #Building Library
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME}
     ${SOURCE_FILES}
 )
 

--- a/sdk/src/utilities/fps/CMakeLists.txt
+++ b/sdk/src/utilities/fps/CMakeLists.txt
@@ -6,4 +6,4 @@ include_directories(
     ${ROOT_DIR}/include/rs/core
 )
 
-add_library(${PROJECT_NAME} SHARED fps_utils.cpp)
+add_library(${PROJECT_NAME} fps_utils.cpp)

--- a/sdk/src/utilities/logger/log_utils/CMakeLists.txt
+++ b/sdk/src/utilities/logger/log_utils/CMakeLists.txt
@@ -4,7 +4,7 @@ project(rs_log_utils)
 set(SOURCE_FILES log_utils.cpp
                  ${ROOT_DIR}/include/rs/utils/log_utils.h)
 
-add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} dl)
 

--- a/sdk/src/utilities/logger/logger/CMakeLists.txt
+++ b/sdk/src/utilities/logger/logger/CMakeLists.txt
@@ -3,7 +3,7 @@ project(rs_logger)
 
 set(SOURCE_FILES logger.cpp xlevel.cpp)
 
-add_library(${PROJECT_NAME} ${SOURCE_FILES})
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} log4cxx apr-1 aprutil-1 )
 

--- a/sdk/src/utilities/logger/logger/CMakeLists.txt
+++ b/sdk/src/utilities/logger/logger/CMakeLists.txt
@@ -3,7 +3,7 @@ project(rs_logger)
 
 set(SOURCE_FILES logger.cpp xlevel.cpp)
 
-add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} log4cxx apr-1 aprutil-1 )
 


### PR DESCRIPTION
Some people may want to build shared libraries rather than static. By explicitly defining their type in the CMake files the user doesn't get a choice.

By default static libs are built but the user can specify '-DBUILD_SHARED_LIBS:BOOL=ON' in their cmake command to build shared libs.
